### PR TITLE
ci: add Gitleaks secrets detection workflow (#17)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,42 @@
+name: Gitleaks
+
+# Detect secrets in pull request diffs using gitleaks-action.
+#
+# Mirrors the canonical NEAT-AI pattern at
+# stSoftwareAU/NEAT-AI/.github/workflows/quality.yml. Third-party
+# actions are pinned to 40-character commit SHAs (Issue #1756) so a
+# hijacked tag cannot exfiltrate CI secrets.
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+      # Fetch the PR base branch so gitleaks-action's computed commit
+      # range (`<base_sha>^..<head_sha>`) resolves on the runner.
+      # Without this step the action fails with
+      # "fatal: Invalid revision range" because the base ref's parent
+      # is not in the shallow checkout (Issue #1756). Mirrors the
+      # NEAT-AI quality.yml pattern.
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}" || true
+      # gitleaks/gitleaks-action@v2.3.9
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Org-level Gitleaks Pro licence (Issue #1636). Required for
+          # repos under stSoftwareAU/*; without it gitleaks-action exits
+          # with ErrLicense before scanning. Configure in repo or org
+          # secrets.
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,7 @@
   },
   "lock": false,
   "imports": {
-    "@std/assert": "jsr:@std/assert@1.0.13",
-    "@std/cli": "jsr:@std/cli@1.0.17"
+    "@std/assert": "jsr:@std/assert@1.0.19",
+    "@std/cli": "jsr:@std/cli@1.0.29"
   }
 }

--- a/docs/archive/pr-summaries/pr-summary-17.md
+++ b/docs/archive/pr-summaries/pr-summary-17.md
@@ -1,15 +1,23 @@
 ## Summary
 
-Added the Gitleaks Secrets Detection GitHub Actions workflow at `.github/workflows/gitleaks.yml`. The workflow scans pull request diffs for committed secrets using `gitleaks-action`, with third-party actions pinned to 40-character commit SHAs to defend against tag-hijack supply-chain attacks. Closes #17.
+Added the Gitleaks Secrets Detection GitHub Actions workflow at
+`.github/workflows/gitleaks.yml`. The workflow scans pull request diffs for
+committed secrets using `gitleaks-action`, with third-party actions pinned to
+40-character commit SHAs to defend against tag-hijack supply-chain attacks.
+Closes #17.
 
 ## Evidence
 
-This is a CI/configuration-only change — no UI or runtime code is modified, so no screenshot applies.
+This is a CI/configuration-only change — no UI or runtime code is modified, so
+no screenshot applies.
 
 Verification performed:
 
-- `./quality.sh < /dev/null` passes cleanly (deno lint, check, fmt, and all unit tests pass).
-- The new workflow file mirrors the canonical NEAT-AI pattern referenced in the issue, including the `Fetch base branch` step needed for gitleaks-action's commit-range resolution.
+- `./quality.sh < /dev/null` passes cleanly (deno lint, check, fmt, and all unit
+  tests pass).
+- The new workflow file mirrors the canonical NEAT-AI pattern referenced in the
+  issue, including the `Fetch base branch` step needed for gitleaks-action's
+  commit-range resolution.
 - Third-party actions are pinned to commit SHAs:
   - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
   - `gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7` (v2.3.9)
@@ -25,5 +33,7 @@ flowchart LR
 
 ## Test Plan
 
-- Workflow is exercised by GitHub Actions on every pull request (`on: pull_request`); no local Deno tests apply to a CI workflow definition.
-- Existing Deno test suite continues to pass: `deno test --allow-all test/*.ts` reports `4 passed | 0 failed`.
+- Workflow is exercised by GitHub Actions on every pull request
+  (`on: pull_request`); no local Deno tests apply to a CI workflow definition.
+- Existing Deno test suite continues to pass: `deno test --allow-all test/*.ts`
+  reports `4 passed | 0 failed`.

--- a/docs/archive/pr-summaries/pr-summary-17.md
+++ b/docs/archive/pr-summaries/pr-summary-17.md
@@ -1,0 +1,29 @@
+## Summary
+
+Added the Gitleaks Secrets Detection GitHub Actions workflow at `.github/workflows/gitleaks.yml`. The workflow scans pull request diffs for committed secrets using `gitleaks-action`, with third-party actions pinned to 40-character commit SHAs to defend against tag-hijack supply-chain attacks. Closes #17.
+
+## Evidence
+
+This is a CI/configuration-only change — no UI or runtime code is modified, so no screenshot applies.
+
+Verification performed:
+
+- `./quality.sh < /dev/null` passes cleanly (deno lint, check, fmt, and all unit tests pass).
+- The new workflow file mirrors the canonical NEAT-AI pattern referenced in the issue, including the `Fetch base branch` step needed for gitleaks-action's commit-range resolution.
+- Third-party actions are pinned to commit SHAs:
+  - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
+  - `gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7` (v2.3.9)
+
+```mermaid
+flowchart LR
+    A[Pull Request opened] --> B[actions/checkout<br/>fetch-depth: 0]
+    B --> C[Fetch base branch]
+    C --> D[gitleaks-action scan]
+    D -->|secrets found| E[Fail PR check]
+    D -->|clean| F[Pass PR check]
+```
+
+## Test Plan
+
+- Workflow is exercised by GitHub Actions on every pull request (`on: pull_request`); no local Deno tests apply to a CI workflow definition.
+- Existing Deno test suite continues to pass: `deno test --allow-all test/*.ts` reports `4 passed | 0 failed`.


### PR DESCRIPTION
## Summary

Adds the Gitleaks Secrets Detection GitHub Actions workflow at `.github/workflows/gitleaks.yml`. Scans pull request diffs for committed secrets using `gitleaks-action`, with third-party actions pinned to 40-character commit SHAs (Issue #1756) to defend against tag-hijack supply-chain attacks. Closes #17.

## Evidence

CI/configuration-only change — no UI or runtime code modified.

- `./quality.sh < /dev/null` passes: deno lint, check, fmt, and 4/4 unit tests pass.
- Workflow mirrors the canonical NEAT-AI pattern (includes the `Fetch base branch` step required for gitleaks-action's commit-range resolution).
- Actions pinned to commit SHAs:
  - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
  - `gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7` (v2.3.9)

```mermaid
flowchart LR
    A[Pull Request opened] --> B[actions/checkout<br/>fetch-depth: 0]
    B --> C[Fetch base branch]
    C --> D[gitleaks-action scan]
    D -->|secrets found| E[Fail PR check]
    D -->|clean| F[Pass PR check]
```

## Test Plan

- [ ] Workflow runs on this PR and reports a gitleaks scan result.
- [x] Existing Deno test suite still passes (`deno test --allow-all test/*.ts` → 4 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)