### PR TITLE
ci: add Markdown Lint workflow (#19)

### DIFF
--- a/.github/workflows/cspell.json
+++ b/.github/workflows/cspell.json
@@ -2,6 +2,7 @@
   "version": "0.2",
   "language": "en-GB",
   "words": [
+    "denoland",
     "stsoftware"
   ],
   "flagWords": [

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,43 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master, Develop]
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "lts/*"
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+      - name: Run markdownlint-cli2
+        run: markdownlint-cli2
+      # Optional: mirror the local check-mermaid quality gate when Deno
+      # and the worker module are available in the repo (Issue #1683).
+      - name: Detect Deno worker module
+        id: detect-deno
+        run: |
+          if [ -f worker/deno/mod.ts ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      # denoland/setup-deno@v2
+      - if: steps.detect-deno.outputs.present == 'true'
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with:
+          deno-version: v2.x
+      - if: steps.detect-deno.outputs.present == 'true'
+        name: Validate Mermaid blocks
+        run: deno run --allow-read --allow-env=DEBUG,LOG_LEVEL,CONFIG_PATH,OUTPUT_JSON worker/deno/mod.ts check-mermaid

--- a/docs/archive/pr-summaries/pr-summary-19.md
+++ b/docs/archive/pr-summaries/pr-summary-19.md
@@ -1,0 +1,40 @@
+## Summary
+
+Added the `Markdown Lint` GitHub Actions workflow at
+`.github/workflows/markdown-lint.yml` so every push to the default
+branches and every pull request runs `markdownlint-cli2` over the
+repository's Markdown sources. The workflow follows the template from
+the issue: it pins `actions/checkout`, `actions/setup-node`, and
+`denoland/setup-deno` to commit SHAs, installs `markdownlint-cli2` via
+npm, runs it, and conditionally invokes the Deno-based Mermaid checker
+only when `worker/deno/mod.ts` is present (this repo does not ship that
+module, so the Mermaid step is skipped at runtime). Closes #19.
+
+## Evidence
+
+Pure CI/config change — no UI. Verified locally by:
+
+- Parsing the workflow YAML with `@std/yaml` (see test plan below).
+- Running `markdownlint-cli2 README.md` locally: `0 error(s)`.
+- Running `./quality.sh`: 6 tests passed, 0 failed.
+
+```mermaid
+flowchart LR
+    A[Push / PR] --> B[checkout]
+    B --> C[setup-node lts/*]
+    C --> D[npm i -g markdownlint-cli2]
+    D --> E[markdownlint-cli2]
+    E --> F{worker/deno/mod.ts?}
+    F -- yes --> G[setup-deno + check-mermaid]
+    F -- no --> H[skip]
+```
+
+## Test Plan
+
+- Added `test/MarkdownLintWorkflow.ts` with two Deno tests:
+  - `markdown-lint workflow file exists` — asserts the workflow file is
+    a regular file.
+  - `markdown-lint workflow parses as YAML and defines markdownlint
+    job` — parses the YAML, then asserts `name`, `jobs.markdownlint`,
+    `runs-on`, and that a step invokes `markdownlint-cli2`.
+- Confirmed `./quality.sh` passes (`6 passed | 0 failed`).

--- a/test/MarkdownLintWorkflow.ts
+++ b/test/MarkdownLintWorkflow.ts
@@ -1,0 +1,35 @@
+// Verifies the Markdown Lint GitHub Actions workflow file exists and is
+// well-formed YAML. Tracked in issue #19.
+import { assert, assertEquals } from "@std/assert";
+import { parse } from "jsr:@std/yaml@1";
+
+const WORKFLOW_PATH = ".github/workflows/markdown-lint.yml";
+
+Deno.test("markdown-lint workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a regular file`);
+});
+
+Deno.test("markdown-lint workflow parses as YAML and defines markdownlint job", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  // deno-lint-ignore no-explicit-any
+  const doc = parse(text) as any;
+
+  assertEquals(doc.name, "Markdown Lint");
+  assert(doc.jobs?.markdownlint, "jobs.markdownlint must be defined");
+  assertEquals(doc.jobs.markdownlint["runs-on"], "ubuntu-latest");
+
+  const steps = doc.jobs.markdownlint.steps as Array<Record<string, unknown>>;
+  assert(
+    Array.isArray(steps) && steps.length > 0,
+    "steps must be a non-empty array",
+  );
+
+  const runs = steps
+    .map((s) => (typeof s.run === "string" ? s.run : ""))
+    .join("\n");
+  assert(
+    runs.includes("markdownlint-cli2"),
+    "workflow must invoke markdownlint-cli2",
+  );
+});


### PR DESCRIPTION
## Summary

Added the `Markdown Lint` GitHub Actions workflow at `.github/workflows/markdown-lint.yml` so every push to default branches and every pull request runs `markdownlint-cli2` over the repository's Markdown sources. Workflow pins `actions/checkout`, `actions/setup-node`, and `denoland/setup-deno` to commit SHAs, installs `markdownlint-cli2` via npm, runs it, and conditionally invokes the Deno-based Mermaid checker only when `worker/deno/mod.ts` is present (skipped here — that module is not shipped in this repo).

Closes #19

## Evidence

Pure CI/config change — no UI. Verified locally by:

- Running `markdownlint-cli2 README.md` → `0 error(s)`.
- Running `./quality.sh` → `6 passed | 0 failed`.

```mermaid
flowchart LR
    A[Push / PR] --> B[checkout]
    B --> C[setup-node lts/*]
    C --> D[npm i -g markdownlint-cli2]
    D --> E[markdownlint-cli2]
    E --> F{worker/deno/mod.ts?}
    F -- yes --> G[setup-deno + check-mermaid]
    F -- no --> H[skip]
```

## Test Plan

- [x] `test/MarkdownLintWorkflow.ts::markdown-lint workflow file exists` — asserts the workflow file is a regular file.
- [x] `test/MarkdownLintWorkflow.ts::markdown-lint workflow parses as YAML and defines markdownlint job` — parses the YAML and asserts on `name`, `jobs.markdownlint`, `runs-on`, and presence of a `markdownlint-cli2` step.
- [x] `./quality.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)