### PR TITLE
Add ShellCheck workflow (#20)

### DIFF
--- a/.github/workflows/cspell.json
+++ b/.github/workflows/cspell.json
@@ -3,6 +3,9 @@
   "language": "en-GB",
   "words": [
     "denoland",
+    "linted",
+    "ludeeus",
+    "shellcheck",
     "stsoftware"
   ],
   "flagWords": [

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+name: ShellCheck
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master, Develop]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # ludeeus/action-shellcheck pinned to commit SHA (Issue #20)
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca
+        with:
+          scandir: .
+          severity: warning

--- a/deno.json
+++ b/deno.json
@@ -8,6 +8,7 @@
   "lock": false,
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.19",
-    "@std/cli": "jsr:@std/cli@1.0.29"
+    "@std/cli": "jsr:@std/cli@1.0.29",
+    "@std/yaml": "jsr:@std/yaml@1"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -9,6 +9,6 @@
   "imports": {
     "@std/assert": "jsr:@std/assert@1.0.19",
     "@std/cli": "jsr:@std/cli@1.0.29",
-    "@std/yaml": "jsr:@std/yaml@1"
+    "@std/yaml": "jsr:@std/yaml@^1.1.0"
   }
 }

--- a/docs/archive/pr-summaries/pr-summary-19.md
+++ b/docs/archive/pr-summaries/pr-summary-19.md
@@ -1,14 +1,14 @@
 ## Summary
 
 Added the `Markdown Lint` GitHub Actions workflow at
-`.github/workflows/markdown-lint.yml` so every push to the default
-branches and every pull request runs `markdownlint-cli2` over the
-repository's Markdown sources. The workflow follows the template from
-the issue: it pins `actions/checkout`, `actions/setup-node`, and
-`denoland/setup-deno` to commit SHAs, installs `markdownlint-cli2` via
-npm, runs it, and conditionally invokes the Deno-based Mermaid checker
-only when `worker/deno/mod.ts` is present (this repo does not ship that
-module, so the Mermaid step is skipped at runtime). Closes #19.
+`.github/workflows/markdown-lint.yml` so every push to the default branches and
+every pull request runs `markdownlint-cli2` over the repository's Markdown
+sources. The workflow follows the template from the issue: it pins
+`actions/checkout`, `actions/setup-node`, and `denoland/setup-deno` to commit
+SHAs, installs `markdownlint-cli2` via npm, runs it, and conditionally invokes
+the Deno-based Mermaid checker only when `worker/deno/mod.ts` is present (this
+repo does not ship that module, so the Mermaid step is skipped at runtime).
+Closes #19.
 
 ## Evidence
 
@@ -32,9 +32,10 @@ flowchart LR
 ## Test Plan
 
 - Added `test/MarkdownLintWorkflow.ts` with two Deno tests:
-  - `markdown-lint workflow file exists` — asserts the workflow file is
-    a regular file.
+  - `markdown-lint workflow file exists` — asserts the workflow file is a
+    regular file.
   - `markdown-lint workflow parses as YAML and defines markdownlint
-    job` — parses the YAML, then asserts `name`, `jobs.markdownlint`,
-    `runs-on`, and that a step invokes `markdownlint-cli2`.
+    job` —
+    parses the YAML, then asserts `name`, `jobs.markdownlint`, `runs-on`, and
+    that a step invokes `markdownlint-cli2`.
 - Confirmed `./quality.sh` passes (`6 passed | 0 failed`).

--- a/docs/archive/pr-summaries/pr-summary-20.md
+++ b/docs/archive/pr-summaries/pr-summary-20.md
@@ -1,0 +1,27 @@
+## Summary
+
+Added the `ShellCheck` GitHub Actions workflow at `.github/workflows/shellcheck.yml` so shell scripts in this repo (currently `quality.sh`) are linted on every pull request and on pushes to default branches. Third-party actions are pinned to 40-character commit SHAs per the project's supply-chain guidelines, rather than the `@master` reference suggested in the issue template. Closes #20.
+
+## Evidence
+
+This is a CI/workflow change with no UI surface. Validation:
+
+- `shellcheck quality.sh` runs locally with no findings — the workflow will report a clean pass on first run.
+- `./quality.sh` passes including the three new tests in `test/ShellCheckWorkflow.ts`.
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> CO[actions/checkout]
+    CO --> SC[ludeeus/action-shellcheck]
+    SC -->|severity: warning| R{Findings?}
+    R -- none --> P[Pass]
+    R -- yes --> F[Fail]
+```
+
+## Test Plan
+
+- Added `test/ShellCheckWorkflow.ts` with three Deno tests:
+  - `shellcheck workflow file exists` — asserts the workflow file is present.
+  - `shellcheck workflow parses as YAML and defines shellcheck job` — asserts structure, `runs-on`, and use of `ludeeus/action-shellcheck`.
+  - `shellcheck workflow pins third-party actions to commit SHAs` — asserts every `uses:` reference resolves to a 40-char SHA (defence against supply-chain attacks).
+- All 9 tests pass under `./quality.sh`.

--- a/docs/archive/pr-summaries/pr-summary-20.md
+++ b/docs/archive/pr-summaries/pr-summary-20.md
@@ -1,13 +1,20 @@
 ## Summary
 
-Added the `ShellCheck` GitHub Actions workflow at `.github/workflows/shellcheck.yml` so shell scripts in this repo (currently `quality.sh`) are linted on every pull request and on pushes to default branches. Third-party actions are pinned to 40-character commit SHAs per the project's supply-chain guidelines, rather than the `@master` reference suggested in the issue template. Closes #20.
+Added the `ShellCheck` GitHub Actions workflow at
+`.github/workflows/shellcheck.yml` so shell scripts in this repo (currently
+`quality.sh`) are linted on every pull request and on pushes to default
+branches. Third-party actions are pinned to 40-character commit SHAs per the
+project's supply-chain guidelines, rather than the `@master` reference suggested
+in the issue template. Closes #20.
 
 ## Evidence
 
 This is a CI/workflow change with no UI surface. Validation:
 
-- `shellcheck quality.sh` runs locally with no findings — the workflow will report a clean pass on first run.
-- `./quality.sh` passes including the three new tests in `test/ShellCheckWorkflow.ts`.
+- `shellcheck quality.sh` runs locally with no findings — the workflow will
+  report a clean pass on first run.
+- `./quality.sh` passes including the three new tests in
+  `test/ShellCheckWorkflow.ts`.
 
 ```mermaid
 flowchart LR
@@ -22,6 +29,9 @@ flowchart LR
 
 - Added `test/ShellCheckWorkflow.ts` with three Deno tests:
   - `shellcheck workflow file exists` — asserts the workflow file is present.
-  - `shellcheck workflow parses as YAML and defines shellcheck job` — asserts structure, `runs-on`, and use of `ludeeus/action-shellcheck`.
-  - `shellcheck workflow pins third-party actions to commit SHAs` — asserts every `uses:` reference resolves to a 40-char SHA (defence against supply-chain attacks).
+  - `shellcheck workflow parses as YAML and defines shellcheck job` — asserts
+    structure, `runs-on`, and use of `ludeeus/action-shellcheck`.
+  - `shellcheck workflow pins third-party actions to commit SHAs` — asserts
+    every `uses:` reference resolves to a 40-char SHA (defence against
+    supply-chain attacks).
 - All 9 tests pass under `./quality.sh`.

--- a/test/MarkdownLintWorkflow.ts
+++ b/test/MarkdownLintWorkflow.ts
@@ -1,7 +1,7 @@
 // Verifies the Markdown Lint GitHub Actions workflow file exists and is
 // well-formed YAML. Tracked in issue #19.
 import { assert, assertEquals } from "@std/assert";
-import { parse } from "jsr:@std/yaml@1";
+import { parse } from "@std/yaml";
 
 const WORKFLOW_PATH = ".github/workflows/markdown-lint.yml";
 

--- a/test/ShellCheckWorkflow.ts
+++ b/test/ShellCheckWorkflow.ts
@@ -1,0 +1,52 @@
+// Verifies the ShellCheck GitHub Actions workflow file exists and is
+// well-formed YAML. Tracked in issue #20.
+import { assert, assertEquals } from "@std/assert";
+import { parse } from "jsr:@std/yaml@1";
+
+const WORKFLOW_PATH = ".github/workflows/shellcheck.yml";
+
+Deno.test("shellcheck workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a regular file`);
+});
+
+Deno.test("shellcheck workflow parses as YAML and defines shellcheck job", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  // deno-lint-ignore no-explicit-any
+  const doc = parse(text) as any;
+
+  assertEquals(doc.name, "ShellCheck");
+  assert(doc.jobs?.shellcheck, "jobs.shellcheck must be defined");
+  assertEquals(doc.jobs.shellcheck["runs-on"], "ubuntu-latest");
+
+  const steps = doc.jobs.shellcheck.steps as Array<Record<string, unknown>>;
+  assert(
+    Array.isArray(steps) && steps.length > 0,
+    "steps must be a non-empty array",
+  );
+
+  const usesValues = steps
+    .map((s) => (typeof s.uses === "string" ? s.uses : ""))
+    .join("\n");
+  assert(
+    usesValues.includes("ludeeus/action-shellcheck"),
+    "workflow must invoke ludeeus/action-shellcheck",
+  );
+});
+
+Deno.test("shellcheck workflow pins third-party actions to commit SHAs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  // deno-lint-ignore no-explicit-any
+  const doc = parse(text) as any;
+  const steps = doc.jobs.shellcheck.steps as Array<Record<string, unknown>>;
+
+  for (const step of steps) {
+    const uses = typeof step.uses === "string" ? step.uses : "";
+    if (!uses) continue;
+    const ref = uses.split("@")[1] ?? "";
+    assert(
+      /^[0-9a-f]{40}$/.test(ref),
+      `step uses '${uses}' must be pinned to a 40-char commit SHA, not a tag/branch`,
+    );
+  }
+});

--- a/test/ShellCheckWorkflow.ts
+++ b/test/ShellCheckWorkflow.ts
@@ -1,7 +1,7 @@
 // Verifies the ShellCheck GitHub Actions workflow file exists and is
 // well-formed YAML. Tracked in issue #20.
 import { assert, assertEquals } from "@std/assert";
-import { parse } from "jsr:@std/yaml@1";
+import { parse } from "@std/yaml";
 
 const WORKFLOW_PATH = ".github/workflows/shellcheck.yml";
 


### PR DESCRIPTION
## Summary

Added the `ShellCheck` GitHub Actions workflow at `.github/workflows/shellcheck.yml` so shell scripts in this repo (currently `quality.sh`) are linted on every pull request and on pushes to default branches. Third-party actions are pinned to 40-character commit SHAs per the project's supply-chain guidelines, rather than the `@master` reference suggested in the issue template. Closes #20.

## Evidence

This is a CI/workflow change with no UI surface. Validation:

- `shellcheck quality.sh` runs locally with no findings — the workflow will report a clean pass on first run.
- `./quality.sh` passes including the three new tests in `test/ShellCheckWorkflow.ts`.

```mermaid
flowchart LR
    PR[Pull Request] --> CO[actions/checkout]
    CO --> SC[ludeeus/action-shellcheck]
    SC -->|severity: warning| R{Findings?}
    R -- none --> P[Pass]
    R -- yes --> F[Fail]
```

## Test Plan

- Added `test/ShellCheckWorkflow.ts` with three Deno tests:
  - `shellcheck workflow file exists` — asserts the workflow file is present.
  - `shellcheck workflow parses as YAML and defines shellcheck job` — asserts structure, `runs-on`, and use of `ludeeus/action-shellcheck`.
  - `shellcheck workflow pins third-party actions to commit SHAs` — asserts every `uses:` reference resolves to a 40-char SHA (defence against supply-chain attacks).
- All 9 tests pass under `./quality.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)