### PR TITLE
ci: upgrade markdown-lint workflow to Node 24 action SHAs (#27)

### DIFF
--- a/.github/workflows/cspell.json
+++ b/.github/workflows/cspell.json
@@ -6,6 +6,7 @@
     "linted",
     "lockstep",
     "ludeeus",
+    "repins",
     "semgrep",
     "Semgrep",
     "shellcheck",

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -13,10 +13,10 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v4
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      # actions/setup-node@v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      # actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      # actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: "lts/*"
       - name: Install markdownlint-cli2

--- a/docs/archive/pr-summaries/pr-summary-27.md
+++ b/docs/archive/pr-summaries/pr-summary-27.md
@@ -1,0 +1,32 @@
+## Summary
+
+Upgrade the Markdown Lint workflow to Node.js 24-compatible action versions.
+GitHub deprecated Node.js 20 runners on the GitHub Actions platform; the
+existing pins for `actions/checkout@v4` and `actions/setup-node@v4` triggered
+deprecation warnings on every run. This PR repins both actions to their
+v5 commit SHAs, which ship with Node.js 24. Closes #27.
+
+## Evidence
+
+Backend/workflow change — no UI to screenshot. Verified by:
+
+- `./quality.sh` passes locally (17 tests, 0 failures).
+- New regression tests fail against the previous v4 SHAs and pass with the
+  v5 SHAs (see Test Plan below).
+
+Pin changes in `.github/workflows/markdown-lint.yml`:
+
+| Action | Before (Node 20) | After (Node 24) |
+| --- | --- | --- |
+| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4) | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` (v5) |
+| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4) | `a0853c24544627f65ddf259abe73b1d18a591444` (v5) |
+
+## Test Plan
+
+Added two regression tests to `test/MarkdownLintWorkflow.ts`:
+
+- `markdown-lint workflow does not use deprecated Node 20 action SHAs` —
+  asserts the old v4 SHAs for `actions/checkout` and `actions/setup-node`
+  are no longer present.
+- `markdown-lint workflow pins actions/checkout and actions/setup-node to
+  Node 24 SHAs` — asserts the new v5 SHAs are pinned.

--- a/docs/archive/pr-summaries/pr-summary-27.md
+++ b/docs/archive/pr-summaries/pr-summary-27.md
@@ -3,30 +3,31 @@
 Upgrade the Markdown Lint workflow to Node.js 24-compatible action versions.
 GitHub deprecated Node.js 20 runners on the GitHub Actions platform; the
 existing pins for `actions/checkout@v4` and `actions/setup-node@v4` triggered
-deprecation warnings on every run. This PR repins both actions to their
-v5 commit SHAs, which ship with Node.js 24. Closes #27.
+deprecation warnings on every run. This PR repins both actions to their v5
+commit SHAs, which ship with Node.js 24. Closes #27.
 
 ## Evidence
 
 Backend/workflow change — no UI to screenshot. Verified by:
 
 - `./quality.sh` passes locally (17 tests, 0 failures).
-- New regression tests fail against the previous v4 SHAs and pass with the
-  v5 SHAs (see Test Plan below).
+- New regression tests fail against the previous v4 SHAs and pass with the v5
+  SHAs (see Test Plan below).
 
 Pin changes in `.github/workflows/markdown-lint.yml`:
 
-| Action | Before (Node 20) | After (Node 24) |
-| --- | --- | --- |
-| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4) | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` (v5) |
+| Action               | Before (Node 20)                                | After (Node 24)                                 |
+| -------------------- | ----------------------------------------------- | ----------------------------------------------- |
+| `actions/checkout`   | `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4) | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` (v5) |
 | `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4) | `a0853c24544627f65ddf259abe73b1d18a591444` (v5) |
 
 ## Test Plan
 
 Added two regression tests to `test/MarkdownLintWorkflow.ts`:
 
-- `markdown-lint workflow does not use deprecated Node 20 action SHAs` —
-  asserts the old v4 SHAs for `actions/checkout` and `actions/setup-node`
-  are no longer present.
+- `markdown-lint workflow does not use deprecated Node 20 action SHAs` — asserts
+  the old v4 SHAs for `actions/checkout` and `actions/setup-node` are no longer
+  present.
 - `markdown-lint workflow pins actions/checkout and actions/setup-node to
-  Node 24 SHAs` — asserts the new v5 SHAs are pinned.
+  Node 24 SHAs`
+  — asserts the new v5 SHAs are pinned.

--- a/test/MarkdownLintWorkflow.ts
+++ b/test/MarkdownLintWorkflow.ts
@@ -33,3 +33,39 @@ Deno.test("markdown-lint workflow parses as YAML and defines markdownlint job", 
     "workflow must invoke markdownlint-cli2",
   );
 });
+
+// Issue #27: GitHub deprecated Node.js 20 actions. The workflow must pin
+// to action versions that ship with the Node 24 runtime.
+Deno.test("markdown-lint workflow does not use deprecated Node 20 action SHAs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+
+  // actions/checkout v4 — Node 20
+  assert(
+    !text.includes("34e114876b0b11c390a56381ad16ebd13914f8d5"),
+    "actions/checkout v4 (Node 20) SHA must not be used; upgrade to v5",
+  );
+  // actions/setup-node v4 — Node 20
+  assert(
+    !text.includes("49933ea5288caeca8642d1e84afbd3f7d6820020"),
+    "actions/setup-node v4 (Node 20) SHA must not be used; upgrade to v5",
+  );
+});
+
+Deno.test("markdown-lint workflow pins actions/checkout and actions/setup-node to Node 24 SHAs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+
+  // actions/checkout@v5 (Node 24)
+  assert(
+    text.includes(
+      "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd",
+    ),
+    "expected actions/checkout pinned to v5 SHA 93cb6efe...",
+  );
+  // actions/setup-node@v5 (Node 24)
+  assert(
+    text.includes(
+      "actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444",
+    ),
+    "expected actions/setup-node pinned to v5 SHA a0853c24...",
+  );
+});


### PR DESCRIPTION
## Summary

Upgrade the Markdown Lint workflow to Node.js 24-compatible action versions.
GitHub deprecated Node.js 20 runners on the GitHub Actions platform; the
existing pins for `actions/checkout@v4` and `actions/setup-node@v4` triggered
deprecation warnings on every run. This PR repins both actions to their
v5 commit SHAs, which ship with Node.js 24. Closes #27.

## Evidence

Backend/workflow change — no UI to screenshot. Verified by:

- `./quality.sh` passes locally (17 tests, 0 failures).
- New regression tests fail against the previous v4 SHAs and pass with the
  v5 SHAs (see Test Plan below).

Pin changes in `.github/workflows/markdown-lint.yml`:

| Action | Before (Node 20) | After (Node 24) |
| --- | --- | --- |
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4) | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` (v5) |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4) | `a0853c24544627f65ddf259abe73b1d18a591444` (v5) |

## Test Plan

Added two regression tests to `test/MarkdownLintWorkflow.ts`:

- `markdown-lint workflow does not use deprecated Node 20 action SHAs` —
  asserts the old v4 SHAs for `actions/checkout` and `actions/setup-node`
  are no longer present.
- `markdown-lint workflow pins actions/checkout and actions/setup-node to
  Node 24 SHAs` — asserts the new v5 SHAs are pinned.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-27 -->